### PR TITLE
Add #content and #content_csv

### DIFF
--- a/lib/ckan/resource.rb
+++ b/lib/ckan/resource.rb
@@ -1,3 +1,5 @@
+require 'csv'
+require 'open-uri'
 require 'time'
 
 module CKAN
@@ -144,6 +146,26 @@ module CKAN
       post_body << "\r\n--#{BOUNDARY}--\r\n"
 
       post_body.join
+    end
+    
+    # Gets the content of this resource as a CSV::Table
+    # options defaults to the same options as CSV.table
+    def content_csv(options={headers: true, converters: :numeric, header_converters: :symbol})
+      CSV.parse content, options
+    end
+    
+    # Gets the content of this resource, from the internet if appropriate
+    def content
+      @content || open(url_safe).read
+    end
+    
+    # Gets the URL of the resource safely - some CKAN APIs return this
+    # containing invalid characters such as spaces.
+    # If URI thinks this is an invalid URI, escape it
+    def url_safe
+      URI.parse(url).to_s
+    rescue URI::InvalidURIError
+      URI.escape url
     end
 
 =begin

--- a/lib/ckan/resource.rb
+++ b/lib/ckan/resource.rb
@@ -150,8 +150,9 @@ module CKAN
     
     # Gets the content of this resource as a CSV::Table
     # options defaults to the same options as CSV.table
-    def content_csv(options={headers: true, converters: :numeric, header_converters: :symbol})
-      CSV.parse content, options
+    def content_csv(options={headers: true, converters: :all, header_converters: :symbol})
+      content_sanitized = content.encode('UTF-8', invalid: :replace, undef: :replace)
+      CSV.parse content_sanitized, options
     end
     
     # Gets the content of this resource, from the internet if appropriate

--- a/lib/ckan/resource.rb
+++ b/lib/ckan/resource.rb
@@ -151,13 +151,17 @@ module CKAN
     # Gets the content of this resource as a CSV::Table
     # options defaults to the same options as CSV.table
     def content_csv(options={headers: true, converters: :all, header_converters: :symbol})
-      content_sanitized = content.encode('UTF-8', invalid: :replace, undef: :replace)
       CSV.parse content_sanitized, options
     end
     
     # Gets the content of this resource, from the internet if appropriate
     def content
       @content || open(url_safe).read
+    end
+    
+    # Gets the content sanitized to remove any non-UTF-8 characters
+    def content_sanitized
+      content.encode('UTF-8', invalid: :replace, undef: :replace)
     end
     
     # Gets the URL of the resource safely - some CKAN APIs return this

--- a/lib/ckan/resource.rb
+++ b/lib/ckan/resource.rb
@@ -150,18 +150,20 @@ module CKAN
     
     # Gets the content of this resource as a CSV::Table
     # options defaults to the same options as CSV.table
+    # add an :encoding option to refer to a different source encoding
     def content_csv(options={headers: true, converters: :all, header_converters: :symbol})
-      CSV.parse content_sanitized, options
+      CSV.parse content_sanitized(options[:encoding]), options
     end
     
     # Gets the content of this resource, from the internet if appropriate
-    def content
-      @content || open(url_safe).read
+    def content(encoding=nil)
+      mode = encoding ? "r:#{encoding}" : "r"
+      @content || open(url_safe, mode).read
     end
     
     # Gets the content sanitized to remove any non-UTF-8 characters
-    def content_sanitized
-      content.encode('UTF-8', invalid: :replace, undef: :replace)
+    def content_sanitized(source_encoding=nil)
+      content(source_encoding).encode('UTF-8', invalid: :replace, undef: :replace)
     end
     
     # Gets the URL of the resource safely - some CKAN APIs return this

--- a/spec/ckan/resource_spec.rb
+++ b/spec/ckan/resource_spec.rb
@@ -122,6 +122,20 @@ describe CKAN::Resource do
         it 'can be called with overridden options' do
           subject.content_csv(headers: false).first.first.should eq('foo')
         end
+        context 'iso-8859-1 data' do
+          before(:each) do
+            stub_request(:get, subject.url).to_return({
+              status: 200,
+              headers: {'Content-Type' => 'text/csv'},
+              body: "foo,bar,baz\nWibbl\xe9,Wobbl\xe9,Woo\xe9\n"
+            })
+          end
+          it 'can get content in a different encoding' do
+            data = subject.content_csv(headers: true, encoding: 'iso-8859-1')
+            data.first['foo'].should eq("Wibblé")
+            data.first['baz'].should eq("Wooé")
+          end
+        end
       end
       context 'when @content is set' do
         before(:each) { subject.content = "foo,bar,baz\nOne,Two,Three\n" }


### PR DESCRIPTION
The current implementation allows the user to _set_ content for the purpose of uploading but doesn't allow them to _get_ content from upstream.

This adds a `#content` method that retrieves the content if it hasn't already been set, and a `#content_csv` that parses it into a CSV::Table.
