### PR TITLE
fix: ensure RubyGems via HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ckan.gemspec
 gemspec


### PR DESCRIPTION
> [REMOVED] The source :rubygems is disallowed because HTTP requests are insecure.
Please change your source to 'https://rubygems.org/' if possible, or
'http://rubygems.org/' if not